### PR TITLE
refactor(comments): useEffect의 fetch를 async IIFE + cancel flag로

### DIFF
--- a/app/components/Comments.tsx
+++ b/app/components/Comments.tsx
@@ -84,9 +84,24 @@ function CommentsClient({ postSlug }: CommentsProps) {
   }, [normalizedSlug]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- 별도 PR에서 async IIFE + cancel flag 패턴으로 리팩토링 예정
-    fetchComments();
-  }, [fetchComments]);
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/comments?postSlug=${normalizedSlug}`);
+        const data = await res.json();
+        if (!cancelled) setComments(data.comments || []);
+      } catch (error) {
+        console.error('Failed to fetch comments:', error);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalizedSlug]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary

이전 PR(#79)에서 `react-hooks/set-state-in-effect` 룰을 `eslint-disable-next-line`으로 우회했던 부분의 후속 작업.

## 변경 내용

- 마운트 시 fetch를 effect 안 async IIFE로 inline
- `cancelled` flag로 unmount 이후 setState 가드 (cleanup 함수에서 토글)
- effect 의존성 `[fetchComments]` → `[normalizedSlug]`로 단순화 (둘은 동등)
- `fetchComments` useCallback은 유지 — handleSubmit/Edit/Delete에서 후속 fetch로 재사용
- 이전 `eslint-disable` 코멘트 제거

## Test plan

- [x] `npm run lint` 통과 (룰 직접 통과, disable 없이)
- [x] `npm run typecheck` 통과
- [x] `npm run build` 통과
- [x] CI Deploy to Netlify ✓
- [ ] preview에서 댓글 마운트/언마운트(페이지 이동) 동작 확인 필요