### PR TITLE
fix(deps): resvg를 공용 npm으로 resolve + .npmrc 추가 (Nexus 403 CD 실패 해결)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# 개인 레포 — 공용 npm 레지스트리 사용.
+# 업무 머신의 전역 ~/.npmrc(사내 Nexus)가 흘러들어와 lockfile을 오염시키는 것을 방지한다.
+# (CI/CD도 이 레지스트리로 의존성을 받는다)
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -5176,7 +5176,7 @@
     },
     "node_modules/@resvg/resvg-js": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
       "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
       "dev": true,
       "license": "MPL-2.0",
@@ -5200,7 +5200,7 @@
     },
     "node_modules/@resvg/resvg-js-android-arm-eabi": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
       "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
       "cpu": [
         "arm"
@@ -5217,7 +5217,7 @@
     },
     "node_modules/@resvg/resvg-js-android-arm64": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
       "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
       "cpu": [
         "arm64"
@@ -5234,7 +5234,7 @@
     },
     "node_modules/@resvg/resvg-js-darwin-arm64": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
       "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
       "cpu": [
         "arm64"
@@ -5251,7 +5251,7 @@
     },
     "node_modules/@resvg/resvg-js-darwin-x64": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
       "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
       "cpu": [
         "x64"
@@ -5268,7 +5268,7 @@
     },
     "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
       "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
       "cpu": [
         "arm"
@@ -5285,7 +5285,7 @@
     },
     "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
       "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
       "cpu": [
         "arm64"
@@ -5305,7 +5305,7 @@
     },
     "node_modules/@resvg/resvg-js-linux-arm64-musl": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
       "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
       "cpu": [
         "arm64"
@@ -5325,7 +5325,7 @@
     },
     "node_modules/@resvg/resvg-js-linux-x64-gnu": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
       "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
       "cpu": [
         "x64"
@@ -5345,7 +5345,7 @@
     },
     "node_modules/@resvg/resvg-js-linux-x64-musl": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
       "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
       "cpu": [
         "x64"
@@ -5365,7 +5365,7 @@
     },
     "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
       "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
       "cpu": [
         "arm64"
@@ -5382,7 +5382,7 @@
     },
     "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
       "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
       "cpu": [
         "ia32"
@@ -5399,7 +5399,7 @@
     },
     "node_modules/@resvg/resvg-js-win32-x64-msvc": {
       "version": "2.6.2",
-      "resolved": "https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
       "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
       "cpu": [
         "x64"


### PR DESCRIPTION
## 문제

[#81](https://github.com/nahyeongjin1/NHJ.log/pull/81) 머지 후 **"Deploy to Netlify" CD가 `npm ci` 단계에서 실패**했습니다.

```
npm error 403 Forbidden - GET https://nexus.mng.musinsa.io/repository/npm-all/@resvg/resvg-js/-/resvg-js-2.6.2.tgz
```

## 원인

OG 이미지 재생성용으로 추가한 `@resvg/resvg-js`를 **업무 머신 전역 `~/.npmrc`(사내 Nexus 레지스트리)**로 설치하는 바람에, `package-lock.json`의 `resolved` URL이 Nexus 경로로 박혔습니다(13개 = resvg + 플랫폼 바이너리 12개). 사내 Nexus는 이 패키지를 보안정책으로 403 차단합니다.

이 레포의 나머지 1543개 의존성은 원래 `registry.npmjs.org`(공용 npm)이고, CI도 그걸 정상적으로 받습니다 — 즉 **Nexus로 박힌 resvg만 예외였던 것**.

## 수정

- **프로젝트 `.npmrc` 추가** (`registry=https://registry.npmjs.org/`) — 개인 레포는 공용 npm 사용, 전역 Nexus 설정이 흘러들어와 lockfile을 오염시키는 것을 방지(재발 차단)
- **lockfile의 `@resvg` `resolved` URL을 npmjs.org로 정정** — Nexus는 npmjs.org 프록시라 tarball·integrity가 동일하므로 prefix만 교체(버전/무결성 변화 없음)

`package.json`은 그대로 → **OG 재생성 자동화(`npm run generate-og`)는 유지**됩니다.

## 검증

- `npm ci` ✅ — 공용 npm에서 resvg(리눅스 바이너리 포함) 포함 전체 설치 성공 (CI 재현)
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run generate-og` ✅ — 동일 이미지 재생성(자동화 동작 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
